### PR TITLE
Fix bad requests if no 'card_link' is present

### DIFF
--- a/github.com/kanban/projects.user.js
+++ b/github.com/kanban/projects.user.js
@@ -20,6 +20,10 @@ var reviewStates = ['PENDING', 'COMMENTED', 'CHANGES_REQUESTED', 'DISMISSED', 'A
 var reviewColors = ['#ced4da', '#91a7ff', '#f59f00', '#f03e3e', '#40c057', '#faa2c1'];
 
 function getIssueTimeline(card_link, callback) {
+  if (card_link === void 0) {
+    return;
+  }
+
   var cache = ISSUE_REFERENCES_CACHE[card_link];
   if (cache) { return callback(cache); }
 
@@ -39,6 +43,10 @@ function getIssueTimeline(card_link, callback) {
 
 
 function getIssueData(card_link, callback) {
+  if (card_link === void 0) {
+    return;
+  }
+
   var cache = ISSUE_DATA_CACHE[card_link];
   if (cache) { return callback(cache); }
 
@@ -175,6 +183,7 @@ function addPRLinks(card) {
     data.forEach(function(i) {
       if (i.event == 'cross-referenced' && i.source.type === 'issue' && i.source.issue.pull_request) {
         var url = i.source.issue.html_url;
+
         var o = {
           'url': url.replace('/repos', '').replace('api.', ''),
           'number': url.split('/').pop()

--- a/github.com/kanban/projects.user.js
+++ b/github.com/kanban/projects.user.js
@@ -183,7 +183,6 @@ function addPRLinks(card) {
     data.forEach(function(i) {
       if (i.event == 'cross-referenced' && i.source.type === 'issue' && i.source.issue.pull_request) {
         var url = i.source.issue.html_url;
-
         var o = {
           'url': url.replace('/repos', '').replace('api.', ''),
           'number': url.split('/').pop()


### PR DESCRIPTION
There are certain type of cards that don't have any link, provoking bad requests that result in 404. 

Example:

![image](https://cloud.githubusercontent.com/assets/1078228/21979086/b6b950de-dbdd-11e6-95ae-f5addddca561.png)

This PR just check that `card_link` is not undefined and then avoid any further work.